### PR TITLE
Fix printf infinite loop

### DIFF
--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -6,10 +6,11 @@
 // spell-checker:ignore (change!) each's
 // spell-checker:ignore (ToDO) LONGHELP FORMATSTRING templating parameterizing formatstr
 
-use std::io::stdout;
+use std::io::{stdout, Write};
 use std::ops::ControlFlow;
 
 use clap::{crate_version, Arg, ArgAction, Command};
+use uucore::display::Quotable;
 use uucore::error::{UResult, USimpleError, UUsageError};
 use uucore::format::{parse_spec_and_escape, ArgumentIter, FormatArgument};
 use uucore::{format_usage, help_about, help_section, help_usage};
@@ -50,9 +51,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     if let Some(arg) = args.peek() {
         // Check if no arguments were used while parsing the format.
         if Some(arg) == first_arg.as_ref() {
+            stdout().flush()?;
             let warning_message = format!(
-                "warning: ignoring excess arguments, starting with '{}'",
-                args.get_str()
+                "warning: ignoring excess arguments, starting with {}",
+                args.get_str().quote()
             );
             return Err(USimpleError::new(0, warning_message.as_str()));
         }

--- a/src/uu/printf/src/printf.rs
+++ b/src/uu/printf/src/printf.rs
@@ -10,8 +10,8 @@ use std::io::stdout;
 use std::ops::ControlFlow;
 
 use clap::{crate_version, Arg, ArgAction, Command};
-use uucore::error::{UResult, UUsageError};
-use uucore::format::{parse_spec_and_escape, FormatArgument};
+use uucore::error::{UResult, USimpleError, UUsageError};
+use uucore::format::{parse_spec_and_escape, ArgumentIter, FormatArgument};
 use uucore::{format_usage, help_about, help_section, help_usage};
 
 const VERSION: &str = "version";
@@ -46,13 +46,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         };
     }
 
-    while args.peek().is_some() {
-        for item in parse_spec_and_escape(format_string.as_ref()) {
-            match item?.write(stdout(), &mut args)? {
-                ControlFlow::Continue(()) => {}
-                ControlFlow::Break(()) => return Ok(()),
-            };
-        }
+    if args.peek().is_some() {
+        let warning_message = format!(
+            "warning: ignoring excess arguments, starting with '{}'",
+            args.get_str()
+        );
+        return Err(USimpleError::new(0, warning_message.as_str()));
     }
     Ok(())
 }

--- a/src/uucore/src/lib/features/format/argument.rs
+++ b/src/uucore/src/lib/features/format/argument.rs
@@ -14,7 +14,7 @@ use crate::{error::set_exit_code, show_warning};
 ///
 /// The [`FormatArgument::Unparsed`] variant contains a string that can be
 /// parsed into other types. This is used by the `printf` utility.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum FormatArgument {
     Char(char),
     String(String),

--- a/tests/by-util/test_printf.rs
+++ b/tests/by-util/test_printf.rs
@@ -73,6 +73,15 @@ fn escaped_unrecognized() {
 }
 
 #[test]
+fn ignore_excess_arguments() {
+    new_ucmd!()
+        .args(&["a", "b"])
+        .succeeds()
+        .stdout_is("a")
+        .stderr_is("printf: warning: ignoring excess arguments, starting with 'b'\n");
+}
+
+#[test]
 fn sub_string() {
     new_ucmd!()
         .args(&["hello %s", "world"])


### PR DESCRIPTION
Fix printf infinite loop ([#5818](https://github.com/uutils/coreutils/issues/5815)) while there are more parameters than format arguments.

Still WiP:
- print stdout before stderr
- add test